### PR TITLE
Remove specific Darwin version from Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,7 +191,7 @@ GEM
 
 PLATFORMS
   aarch64-linux
-  arm64-darwin-21
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Otherwise, running `bundle install` on my newer Mac would add `arm64-darwin-22` to the list of platforms, and there shouldn't be a need to specify all the individual Darwin kernel versions.