### PR TITLE
Add RSpec GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on:
+  - pull_request
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - env:
+          RAILS_ENV: test
+        run: bin/rails db:setup
+      - env:
+          RAILS_ENV: test
+        run: bin/rails spec


### PR DESCRIPTION
This is to help students get used to industry-standard CI/CD practices. After this is merged, PRs for branches that include this change will run `rspec` so that students can see if they broke any tests. The repo admin (@ElenaCherpakova) should also configure the `dev-main` and `main` branch protection rules such that this workflow is required to pass.